### PR TITLE
feat: Add cookies to ResponseStreamMetadata type

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jill64/types-lambda.git",
-    "image": "https://opengraph.githubassets.com/a1b17e175d3ad4eaaa48f571847b7029f8621f558b00778753f9067ba8f9c792/jill64/types-lambda"
+    "image": "https://opengraph.githubassets.com/d247bbb3152b8a73e9c7c38104da18e2265b97dd6e6bda52157ff60d0a3a805e/jill64/types-lambda"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jill64/types-lambda",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "type": "module",
   "description": "λ Unofficial AWS Lambda type definition",
   "main": "types/index.ts",

--- a/types/streaming/ResponseStreamMetadata.ts
+++ b/types/streaming/ResponseStreamMetadata.ts
@@ -15,4 +15,9 @@ export type ResponseStreamMetadata = {
    * ```
    */
   headers: Record<string, string>
+  /**
+   * HTTP cookies
+   * @example ["cookie1=value1", "cookie2=value2"]
+   */
+  cookies: string[]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new `cookies` field to improve HTTP response handling in streaming services.

- **Documentation**
  - Updated the version and repository image in package metadata for better tracking and visual representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->